### PR TITLE
accept top level redis cluster config

### DIFF
--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -75,6 +75,11 @@ class RedisManager implements Factory
 
         $options = $this->config['options'] ?? [];
 
+        $clusterConfig = $this->getClusterConfig($name);
+        if ($clusterConfig) {
+            return $this->resolveClusterOption($name);
+        }
+
         if (isset($this->config[$name])) {
             return $this->connector()->connect($this->config[$name], $options);
         }
@@ -85,6 +90,41 @@ class RedisManager implements Factory
 
         throw new InvalidArgumentException(
             "Redis connection [{$name}] not configured."
+        );
+    }
+
+    /**
+     * Get the cluster options if it exists 
+     *
+     * @param  string $connection the connection given by name  
+     * @return mixed 
+     *
+     */
+    private function getClusterConfig($connection)
+    {
+        if (isset($this->config[$connection]['clusters'])) {
+            return $this->config[$connection]['clusters']; 
+        } else {
+            return null; 
+        }
+    } 
+
+    /**
+     * Resolve the cluster option
+     * note: this basically does the same job as resolveCluster
+     * but targetig a config where a cluster connection is treated
+     * the same way as the default connection, ie as a first class citizen
+     *
+     * @param  string  $name
+     * @return \Illuminate\Redis\Connections\Connection
+     */
+    protected function resolveClusterOption($name)
+    {
+        // this works if you put the cluster options at the top level
+        $clusterOptions = $this->config[$name]['options'] ?? [];
+
+        return $this->connector()->connectToCluster(
+            $this->config[$name]['clusters'], $clusterOptions, $this->config['options'] ?? []
         );
     }
 
@@ -140,3 +180,5 @@ class RedisManager implements Factory
         return $this->connection()->{$method}(...$parameters);
     }
 }
+
+


### PR DESCRIPTION
# Clustering
the current code only accepts the top level config to be of type
'default' or requires that there be a 'clusters' array like so

    'client' => 'predis',
    'cluster' => env('REDIS_CLUSTER', false),

    //'default' => [
    //    ...
    //],

    // OR

    //'clusters' => [
    //    'default' => [
    //        ...
    //    ],
    //],

this setup prevents the user from being able to specify both a clustered
and non clustered configs, see discussion here:
https://stackoverflow.com/questions/57722659/how-to-have-both-clustered-and-non-clustered-redis-connections-in-laravel
and here
https://github.com/nrk/predis/issues/480#issuecomment-399978155

what this commit does is that it allows the redis config (in
config/database.php) to specify both a clustered config and non
clustered config. Here is an example

    'redis' => [

        'clustered' => [
            'client' => 'predis',
            'cluster' => true,
            'options' => [ 'cluster' => 'redis' ],
            'clusters' => [
                        [
                            'host' => env('REDIS_SHARD_1_HOST', '127.0.01'),
                            'password' => env('REDIS_PASSWORD', null),
                            'port' => env('REDIS_SHARD_1_PORT', 6379),
                            'database' => 0,
                        ],
                        [
                            'host' => env('REDIS_SHARD_2_HOST', '127.0.01'),
                            'password' => env('REDIS_PASSWORD', null),
                            'port' => env('REDIS_SHARD_2_PORT', 6379),
                            'database' => 0,
                        ],
                        [
                            'host' => env('REDIS_SHARD_3_HOST', '127.0.01'),
                            'password' => env('REDIS_PASSWORD', null),
                            'port' => env('REDIS_SHARD_3_PORT', 6379),
                            'database' => 0,
                        ],
            ],
        ],

        'default' => [
            'host' => env('REDIS_HOST', '127.0.0.1'),
            'password' => env('REDIS_PASSWORD', null),
            'port'     => 6379,
            'database' => 0,
            'cluster' => false,
        ],

# Replication
add the ability to include replicas in predis config

this is a sample config,
- replicated configs are treated as first class citizens same as default
- the replicated config must have a `replicas` array, showing the
replicas inside them
- the master node must have 'alias' => master

```
    'redis' => [

        'replicated' => [
            'client' => 'predis',
            'cluster' => false,
            'options' => [ 'replication' => true ],
            'replicas' => [
                        [
                            'host' => env('REDIS_MASTER_HOST', '127.0.01'),
                            'password' => env('REDIS_PASSWORD', null),
                            'port' => env('REDIS_MASTER_PORT', 6379),
                            'database' => 0,
                            'alias' => 'master',
                        ],
                        [
                            'host' => env('REDIS_REPLICA_1_HOST', '127.0.01'),
                            'password' => env('REDIS_PASSWORD', null),
                            'port' => env('REDIS_REPLICA_1_HOST', 6379),
                            'database' => 0,
                        ],
                        [
                            'host' => env('REDIS_REPLICA_2_HOST', '127.0.01'),
                            'password' => env('REDIS_PASSWORD', null),
                            'port' => env('REDIS_REPLICA_2_PORT', 6379),
                            'database' => 0,
                        ],
            ],
        ],

        'default' => [
            'host' => env('REDIS_HOST', '127.0.0.1'),
            'password' => env('REDIS_PASSWORD', null),
            'port'     => 6379,
            'database' => 0,
            'cluster' => false,
        ],
    ]
```

# Clustering AND replication
not currently possible with predis, see https://stackoverflow.com/questions/57761328/how-to-create-a-predis-client-that-does-both-clustering-and-replication
